### PR TITLE
refactor: 전 계층 패키지 구조 정리

### DIFF
--- a/application/src/main/java/dev/chan/api/GlobalExceptionHandler.java
+++ b/application/src/main/java/dev/chan/api/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package dev.chan.common.exception;
+package dev.chan.api;
 
 public class GlobalExceptionHandler {
     // TODO: 글로벌 예외처리 작성 예정

--- a/application/src/main/java/dev/chan/api/dto/ApiResponse.java
+++ b/application/src/main/java/dev/chan/api/dto/ApiResponse.java
@@ -1,4 +1,4 @@
-package dev.chan.common.response;
+package dev.chan.api.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/application/src/main/java/dev/chan/api/file/DriveItemController.java
+++ b/application/src/main/java/dev/chan/api/file/DriveItemController.java
@@ -1,7 +1,7 @@
 package dev.chan.api.file;
 
-import dev.chan.api.file.request.PresignedUrlRequest;
-import dev.chan.api.file.request.UploadCallbackRequest;
+import dev.chan.api.file.dto.PresignedUrlRequest;
+import dev.chan.api.file.dto.UploadCallbackRequest;
 import dev.chan.application.file.DriveItemAppService;
 import dev.chan.application.file.PresignedUrlResponse;
 import dev.chan.application.file.PresignedUrlService;

--- a/application/src/main/java/dev/chan/api/file/dto/ErrorDetail.java
+++ b/application/src/main/java/dev/chan/api/file/dto/ErrorDetail.java
@@ -1,4 +1,4 @@
-package dev.chan.api.file.response;
+package dev.chan.api.file.dto;
 
 public class ErrorDetail {
     String field;

--- a/application/src/main/java/dev/chan/api/file/dto/ErrorReason.java
+++ b/application/src/main/java/dev/chan/api/file/dto/ErrorReason.java
@@ -1,4 +1,4 @@
-package dev.chan.api.file.response;
+package dev.chan.api.file.dto;
 
 public enum ErrorReason {
     REQUIRED, INVALID, NOT_FOUND

--- a/application/src/main/java/dev/chan/api/file/dto/FileMetaDataDto.java
+++ b/application/src/main/java/dev/chan/api/file/dto/FileMetaDataDto.java
@@ -1,4 +1,4 @@
-package dev.chan.api.file.request;
+package dev.chan.api.file.dto;
 
 import dev.chan.domain.file.FileMetadata;
 import lombok.*;

--- a/application/src/main/java/dev/chan/api/file/dto/FileUploadResponse.java
+++ b/application/src/main/java/dev/chan/api/file/dto/FileUploadResponse.java
@@ -1,4 +1,4 @@
-package dev.chan.api.file.response;
+package dev.chan.api.file.dto;
 
 import dev.chan.domain.file.FileMetadata;
 import lombok.Builder;

--- a/application/src/main/java/dev/chan/api/file/dto/PresignedUrlRequest.java
+++ b/application/src/main/java/dev/chan/api/file/dto/PresignedUrlRequest.java
@@ -1,6 +1,6 @@
-package dev.chan.api.file.request;
+package dev.chan.api.file.dto;
 
-import dev.chan.application.command.PresignedUrlCommand;
+import dev.chan.application.dto.PresignedUrlCommand;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/application/src/main/java/dev/chan/api/file/dto/UploadCallbackRequest.java
+++ b/application/src/main/java/dev/chan/api/file/dto/UploadCallbackRequest.java
@@ -1,6 +1,6 @@
-package dev.chan.api.file.request;
+package dev.chan.api.file.dto;
 
-import dev.chan.application.command.UploadCallbackCommand;
+import dev.chan.application.dto.UploadCallbackCommand;
 import lombok.*;
 
 @Getter

--- a/application/src/main/java/dev/chan/application/dto/FolderCreateCommand.java
+++ b/application/src/main/java/dev/chan/application/dto/FolderCreateCommand.java
@@ -1,4 +1,4 @@
-package dev.chan.application.command;
+package dev.chan.application.dto;
 
 
 import dev.chan.common.MimeType;

--- a/application/src/main/java/dev/chan/application/dto/PresignedUrlCommand.java
+++ b/application/src/main/java/dev/chan/application/dto/PresignedUrlCommand.java
@@ -1,7 +1,7 @@
-package dev.chan.application.command;
+package dev.chan.application.dto;
 
 
-import dev.chan.api.file.request.FileMetaDataDto;
+import dev.chan.api.file.dto.FileMetaDataDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/application/src/main/java/dev/chan/application/dto/PresignedUrlSpecification.java
+++ b/application/src/main/java/dev/chan/application/dto/PresignedUrlSpecification.java
@@ -1,4 +1,4 @@
-package dev.chan.application.command;
+package dev.chan.application.dto;
 
 import dev.chan.domain.file.FileMetadata;
 

--- a/application/src/main/java/dev/chan/application/dto/UploadCallbackCommand.java
+++ b/application/src/main/java/dev/chan/application/dto/UploadCallbackCommand.java
@@ -1,4 +1,4 @@
-package dev.chan.application.command;
+package dev.chan.application.dto;
 
 public record UploadCallbackCommand(
         String mimeType,

--- a/application/src/main/java/dev/chan/application/dto/UploadCallbackResult.java
+++ b/application/src/main/java/dev/chan/application/dto/UploadCallbackResult.java
@@ -1,4 +1,4 @@
-package dev.chan.application.vo;
+package dev.chan.application.dto;
 
 import dev.chan.domain.file.DriveItem;
 import dev.chan.domain.userstate.UserItemState;

--- a/application/src/main/java/dev/chan/application/dto/UploadTicket.java
+++ b/application/src/main/java/dev/chan/application/dto/UploadTicket.java
@@ -1,4 +1,4 @@
-package dev.chan.application.vo;
+package dev.chan.application.dto;
 
 import dev.chan.domain.file.FileMetadata;
 

--- a/application/src/main/java/dev/chan/application/file/DriveItemAppService.java
+++ b/application/src/main/java/dev/chan/application/file/DriveItemAppService.java
@@ -1,14 +1,10 @@
 package dev.chan.application.file;
 
-import dev.chan.application.command.FolderCreateCommand;
-import dev.chan.application.command.UploadCallbackCommand;
+import dev.chan.application.dto.FolderCreateCommand;
+import dev.chan.application.dto.UploadCallbackCommand;
+import dev.chan.application.dto.UploadCallbackResult;
 import dev.chan.application.exception.DriveItemNotFoundException;
-import dev.chan.application.vo.UploadCallbackResult;
-import dev.chan.domain.UploadedFileRegisteredEvent;
-import dev.chan.domain.file.DriveItem;
-import dev.chan.domain.file.DriveItemEventPublisher;
-import dev.chan.domain.file.DriveItemFactory;
-import dev.chan.domain.file.DriveItemRepository;
+import dev.chan.domain.file.*;
 import dev.chan.domain.userstate.UserItemState;
 import dev.chan.domain.userstate.UserItemStateRepository;
 import lombok.RequiredArgsConstructor;

--- a/application/src/main/java/dev/chan/application/file/IssueUploadUrlUseCase.java
+++ b/application/src/main/java/dev/chan/application/file/IssueUploadUrlUseCase.java
@@ -1,7 +1,7 @@
 package dev.chan.application.file;
 
 import dev.chan.application.dto.IssueUploadUrlCommand;
-import dev.chan.application.vo.UploadTicket;
+import dev.chan.application.dto.UploadTicket;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/application/src/main/java/dev/chan/application/file/PresignedUrlResponse.java
+++ b/application/src/main/java/dev/chan/application/file/PresignedUrlResponse.java
@@ -1,7 +1,7 @@
 package dev.chan.application.file;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import dev.chan.application.command.PresignedUrlSpecification;
+import dev.chan.application.dto.PresignedUrlSpecification;
 import dev.chan.common.MimeType;
 
 import java.time.Instant;

--- a/application/src/main/java/dev/chan/application/file/PresignedUrlService.java
+++ b/application/src/main/java/dev/chan/application/file/PresignedUrlService.java
@@ -1,9 +1,9 @@
 package dev.chan.application.file;
 
-import dev.chan.application.command.PresignedUrlCommand;
-import dev.chan.application.command.PresignedUrlSpecification;
+import dev.chan.application.dto.PresignedUrlCommand;
+import dev.chan.application.dto.PresignedUrlSpecification;
 import dev.chan.common.util.ThreadPoolLogger;
-import dev.chan.domain.FileKeySpecification;
+import dev.chan.domain.file.FileKeySpecification;
 import dev.chan.infra.config.AwsProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/application/src/main/java/dev/chan/application/file/S3KeyGenerator.java
+++ b/application/src/main/java/dev/chan/application/file/S3KeyGenerator.java
@@ -1,6 +1,6 @@
 package dev.chan.application.file;
 
-import dev.chan.domain.FileKeySpecification;
+import dev.chan.domain.file.FileKeySpecification;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 

--- a/application/src/main/java/dev/chan/application/file/S3PresignedUrlGenerator.java
+++ b/application/src/main/java/dev/chan/application/file/S3PresignedUrlGenerator.java
@@ -1,6 +1,6 @@
 package dev.chan.application.file;
 
-import dev.chan.application.command.PresignedUrlSpecification;
+import dev.chan.application.dto.PresignedUrlSpecification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/application/src/test/java/dev/chan/api/DriveControllerAsyncTest.java
+++ b/application/src/test/java/dev/chan/api/DriveControllerAsyncTest.java
@@ -1,7 +1,7 @@
 package dev.chan.api;
 
-import dev.chan.api.file.request.FileMetaDataDto;
-import dev.chan.application.command.PresignedUrlCommand;
+import dev.chan.api.file.dto.FileMetaDataDto;
+import dev.chan.application.dto.PresignedUrlCommand;
 import dev.chan.application.file.PresignedUrlResponse;
 import dev.chan.application.file.PresignedUrlService;
 import lombok.extern.slf4j.Slf4j;

--- a/application/src/test/java/dev/chan/api/DriveItemControllerTest.java
+++ b/application/src/test/java/dev/chan/api/DriveItemControllerTest.java
@@ -4,7 +4,6 @@ package dev.chan.api;
 import dev.chan.api.file.DriveItemController;
 import dev.chan.application.file.DriveItemAppService;
 import dev.chan.application.file.PresignedUrlService;
-import dev.chan.common.exception.GlobalExceptionHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/application/src/test/java/dev/chan/application/file/DriveItemAppServiceTest.java
+++ b/application/src/test/java/dev/chan/application/file/DriveItemAppServiceTest.java
@@ -1,15 +1,11 @@
 package dev.chan.application.file;
 
 
-import dev.chan.application.command.FolderCreateCommand;
-import dev.chan.application.command.UploadCallbackCommand;
-import dev.chan.application.vo.UploadCallbackResult;
+import dev.chan.application.dto.FolderCreateCommand;
+import dev.chan.application.dto.UploadCallbackCommand;
+import dev.chan.application.dto.UploadCallbackResult;
 import dev.chan.common.MimeType;
-import dev.chan.domain.UploadedFileRegisteredEvent;
-import dev.chan.domain.file.DriveItem;
-import dev.chan.domain.file.DriveItemEventPublisher;
-import dev.chan.domain.file.DriveItemFactory;
-import dev.chan.domain.file.FileMetadata;
+import dev.chan.domain.file.*;
 import dev.chan.domain.userstate.UserItemState;
 import dev.chan.infrastructure.DriveItemMemoryRepository;
 import dev.chan.infrastructure.UserItemStateMemoryRepositoryImpl;

--- a/application/src/test/java/dev/chan/application/file/IssueUploadUrlUseCaseTest.java
+++ b/application/src/test/java/dev/chan/application/file/IssueUploadUrlUseCaseTest.java
@@ -2,7 +2,7 @@ package dev.chan.application.file;
 
 import dev.chan.application.CommandMother;
 import dev.chan.application.dto.IssueUploadUrlCommand;
-import dev.chan.application.vo.UploadTicket;
+import dev.chan.application.dto.UploadTicket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/application/src/test/java/dev/chan/application/file/key/FileKeyGeneratorTest.java
+++ b/application/src/test/java/dev/chan/application/file/key/FileKeyGeneratorTest.java
@@ -1,7 +1,7 @@
 package dev.chan.application.file.key;
 
 import dev.chan.application.file.S3KeyGenerator;
-import dev.chan.domain.FileKeySpecification;
+import dev.chan.domain.file.FileKeySpecification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/application/src/test/java/dev/chan/infrastructure/aws/PresignedUrlServiceIntegrationTest.java
+++ b/application/src/test/java/dev/chan/infrastructure/aws/PresignedUrlServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package dev.chan.infrastructure.aws;
 
-import dev.chan.application.command.PresignedUrlSpecification;
+import dev.chan.application.dto.PresignedUrlSpecification;
 import dev.chan.application.file.PresignedUrlResponse;
 import dev.chan.application.file.S3PresignedUrlGenerator;
 import dev.chan.common.MimeType;

--- a/application/src/test/java/dev/chan/infrastructure/aws/PresignedUrlServiceTest.java
+++ b/application/src/test/java/dev/chan/infrastructure/aws/PresignedUrlServiceTest.java
@@ -1,8 +1,8 @@
 package dev.chan.infrastructure.aws;
 
-import dev.chan.api.file.request.FileMetaDataDto;
-import dev.chan.application.command.PresignedUrlCommand;
-import dev.chan.application.command.PresignedUrlSpecification;
+import dev.chan.api.file.dto.FileMetaDataDto;
+import dev.chan.application.dto.PresignedUrlCommand;
+import dev.chan.application.dto.PresignedUrlSpecification;
 import dev.chan.application.file.PresignedUrlResponse;
 import dev.chan.application.file.PresignedUrlService;
 import dev.chan.application.file.S3KeyGenerator;

--- a/application/src/test/java/dev/chan/infrastructure/aws/S3PresignedUrlGeneratorTest.java
+++ b/application/src/test/java/dev/chan/infrastructure/aws/S3PresignedUrlGeneratorTest.java
@@ -1,6 +1,6 @@
 package dev.chan.infrastructure.aws;
 
-import dev.chan.application.command.PresignedUrlSpecification;
+import dev.chan.application.dto.PresignedUrlSpecification;
 import dev.chan.application.file.PresignedUrlResponse;
 import dev.chan.application.file.S3PresignedUrlGenerator;
 import dev.chan.common.MimeType;

--- a/domain/src/main/java/dev/chan/domain/file/DriveItem.java
+++ b/domain/src/main/java/dev/chan/domain/file/DriveItem.java
@@ -1,6 +1,7 @@
 package dev.chan.domain.file;
 
 import dev.chan.common.MimeType;
+import dev.chan.domain.thumbnail.Thumbnail;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/domain/src/main/java/dev/chan/domain/file/FileKeySpecification.java
+++ b/domain/src/main/java/dev/chan/domain/file/FileKeySpecification.java
@@ -1,4 +1,4 @@
-package dev.chan.domain;
+package dev.chan.domain.file;
 
 
 public record FileKeySpecification(String driveId, String uploadPrefix, String fileName) {

--- a/domain/src/main/java/dev/chan/domain/file/UploadedFileRegisteredEvent.java
+++ b/domain/src/main/java/dev/chan/domain/file/UploadedFileRegisteredEvent.java
@@ -1,4 +1,4 @@
-package dev.chan.domain;
+package dev.chan.domain.file;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/domain/src/main/java/dev/chan/domain/member/User.java
+++ b/domain/src/main/java/dev/chan/domain/member/User.java
@@ -1,4 +1,4 @@
-package dev.chan.domain;
+package dev.chan.domain.member;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/domain/src/main/java/dev/chan/domain/thumbnail/Thumbnail.java
+++ b/domain/src/main/java/dev/chan/domain/thumbnail/Thumbnail.java
@@ -1,4 +1,4 @@
-package dev.chan.domain.file;
+package dev.chan.domain.thumbnail;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/domain/src/main/java/dev/chan/domain/thumbnail/ThumbnailGenerationPolicy.java
+++ b/domain/src/main/java/dev/chan/domain/thumbnail/ThumbnailGenerationPolicy.java
@@ -1,4 +1,4 @@
-package dev.chan.domain.file;
+package dev.chan.domain.thumbnail;
 
 import dev.chan.common.MimeType;
 


### PR DESCRIPTION
- 불필요한 패키지 제거
- 의도에 맞지 않거나 부적합한 패키지 제거 및 클래스 이동

## 📌 작업 개요
- 어떤 이슈를 해결하거나 어떤 기능을 추가했는지 간단히 설명해주세요.

## 🔍 관련 이슈
- Closes #32 , Resolves #32 

## 🛠️ 변경사항 상세
### 전계층 패키지 정리 및 구조 개선
- 현재단계에서 불필요한 패키지 나눔으로 인해 구조가 일관되지 못하고 복잡해진 경향이 있었습니다. 이러한 부분을 해소하기위해 각 계층별 데이터 전송 객체는 DTO 패키지로 통합해 일관성을 부여했습니다.
- VO와 DTO가 혼용되어 역할이 불분명한 클래스들을 각각 역할에 맞게 이동하거나 제거했습니다. 
- Infra로직을 잘게 분리해 구현된 코드대비 복잡도개 매우 높게 올라갔습니다. 이는 결국 개발 속도 저하로 이어졌고, 프로젝트의 혼란을 초래하고있습니다. 그래서 다음과 같은 원칙을 적용하기로 했습니다.
1. YAGNI 
- 앞으로 모듈분리는 반드시 x10 분리해야만 하는 상황에서만 분리합니다. 그리고 패키지를 쪼개고 객체를 생성하는 모든 원칙을 반드시 필요에의해서만 적용하고자 합니다. 
2. KISS
- 당장의 확장가능성을 염두에 두고 지나치게 계층간 데이터 전달 및 코드 구현을 복잡하게 다루지 않기로합니다. 확장 가능성은 항상 개발하면서 염두에 두어야하는 중요한 요소이지만, 이로인해 고민하는 시간이 길어지고 설계가 복잡해져 얻는 이익보다 실이 훨씬 많았습니다. 
따라서 반드시 필요한 상황이 아니라면 최대한 간단하고 심플한 로직을 구현하고, 추후 필요시 개선하고자 합니다. 